### PR TITLE
Deploy all worker at once and make them ready for next task

### DIFF
--- a/core/Thekdar.js
+++ b/core/Thekdar.js
@@ -1,10 +1,10 @@
-const uuid = require("uuid");
-const EventEmitter = require("events");
-const events = require("./events");
-const util = require("util");
-const Task = require("./Task");
-const Worker = require("./Worker");
-const debug = require("debug")("Thekdar:main");
+const uuid = require('uuid');
+const EventEmitter = require('events');
+const events = require('./events');
+const util = require('util');
+const Task = require('./Task');
+const Worker = require('./Worker');
+const debug = require('debug')('Thekdar:main');
 
 class Thekdar extends EventEmitter {
   constructor() {
@@ -16,6 +16,8 @@ class Thekdar extends EventEmitter {
     // How many task a worker have
     this._workerTaskLookup = new Map();
     this._workersAddress = new Map();
+    this._maxWorkers = 20;
+    this._maxTaskPerWorker = 10;
   }
 
   addWorkerAddress(address, workerType) {
@@ -27,26 +29,25 @@ class Thekdar extends EventEmitter {
   }
   addTask(task, workerAddressIndex = -1) {
     if (!task) {
-      throw new Error("Please provide task object instance of Task Class");
+      throw new Error('Please provide task object instance of Task Class');
     }
     if (!task.getType()) {
-      throw new Error("Please provide task type, can be fork, spwan, exec");
+      throw new Error('Please provide task type, can be fork, spwan, exec');
     }
     const taskId = uuid();
     task.setId(taskId);
     try {
       const worker = this._getFreeWorker(task, workerAddressIndex);
+      console.log(worker);
+      return;
       if (!worker) {
-        debug("No Worker found.");
+        debug('No Worker found.');
         return null;
       }
       this._tasks.set(taskId, task);
       worker.addTask(this._tasks.get(taskId));
-      if (!this._workerTaskLookup.get(worker.getId())) {
-        this._workerTaskLookup.set(worker.getId(), []);
-      }
       this._workerTaskLookup.get(worker.getId()).push(task.getId());
-      this.emit("add", { worker });
+      this.emit('add', { worker });
       debug(`New task added, previous task count ${this._tasks.size}`);
       return worker;
     } catch (error) {
@@ -55,8 +56,29 @@ class Thekdar extends EventEmitter {
     }
   }
 
+  /**
+   * Deploy all workers at a time so later we don't
+   * have to create worker just before assigining task.
+   *
+   * @param {*} taskType
+   * @param {*} workerAddressIndex
+   */
+  deployWorkers(taskType = Task.TYPE_FORK, workerAddressIndex) {
+    if (this._isWorkersDeployed) {
+      return false;
+    }
+    this._isWorkersDeployed = true;
+    let workers = this._workers.get(taskType);
+    if (!workers) {
+      this._workers.set(taskType, new Map());
+    }
+    for (let i = 0; i < this._maxWorkers; i++) {
+      const worker = this._createWorker(Task.TYPE_FORK, workerAddressIndex);
+      this._workerTaskLookup.set(worker.getId(), []);
+    }
+  }
   _getFreeWorker(task, workerAddressIndex) {
-    if (this._workerTaskLookup.size > Thekdar.MAX_WORKERS) {
+    if (this._workerTaskLookup.size > this._maxWorkers) {
       throw new Error(
         `Maximum workers are working ${
           this._workerTaskLookup.size
@@ -66,26 +88,32 @@ class Thekdar extends EventEmitter {
     const taskType = task.getType();
     let workers = this._workers.get(taskType);
     let newWorker;
-    if (!workers) {
-      this._workers.set(taskType, new Map());
-      newWorker = this._createWorker(taskType, workerAddressIndex);
-      return newWorker;
-    }
-    for (let [index, worker] of this._workers.get(taskType).entries()) {
-      let lWorker = this._workerTaskLookup.get(worker.getId());
-      if (lWorker.length === Thekdar.MAX_TASK_PER_WORKER - 1) {
-        const nextWorker = this._createWorker(taskType, workerAddressIndex);
-        this._workerTaskLookup.set(nextWorker.getId(), []);
-      }
-      if (lWorker.length >= Thekdar.MAX_TASK_PER_WORKER) {
-        debug("This worker has maximum task.");
-        newWorker = null;
-        continue;
-      } else {
-        newWorker = worker;
-        break;
+    // if (!workers) {
+    //   this._workers.set(taskType, new Map());
+    //   newWorker = this._createWorker(taskType, workerAddressIndex);
+    //   return newWorker;
+    // }
+    for (let [workerId, works] of this._workerTaskLookup) {
+      if (!works.length) {
+        // If very first worker is free then return it
+        return workers.get(workerId);
       }
     }
+    // for (let [index, worker] of this._workers.get(taskType).entries()) {
+    //   let lWorker = this._workerTaskLookup.get(worker.getId());
+    //   if (lWorker.length === Thekdar.MAX_TASK_PER_WORKER - 1) {
+    //     const nextWorker = this._createWorker(taskType, workerAddressIndex);
+    //     this._workerTaskLookup.set(nextWorker.getId(), []);
+    //   }
+    //   if (lWorker.length >= Thekdar.MAX_TASK_PER_WORKER) {
+    //     debug('This worker has maximum task.');
+    //     newWorker = null;
+    //     continue;
+    //   } else {
+    //     newWorker = worker;
+    //     break;
+    //   }
+    // }
     return newWorker;
   }
 
@@ -100,7 +128,7 @@ class Thekdar extends EventEmitter {
     }
     const address = workerAddress[lWorkerAddressIndex];
     if (!address) {
-      throw new Error("Please specify address of worker");
+      throw new Error('Please specify address of worker');
     }
     worker.setAddress(address);
     worker.create();
@@ -120,7 +148,7 @@ class Thekdar extends EventEmitter {
           this.handleTaskComplete(data, worker);
           break;
       }
-      this.emit("message", data);
+      this.emit('message', data);
     };
   }
 
@@ -148,7 +176,7 @@ class Thekdar extends EventEmitter {
       const worker = this._workers.get(task.getType()).get(workerId);
       worker.removeTask(taskId);
       this._tasks.delete(taskId);
-      debug("A task deleted with id of %s", taskId);
+      debug('A task deleted with id of %s', taskId);
       return true;
     } catch (er) {
       debug(er);
@@ -167,7 +195,7 @@ class Thekdar extends EventEmitter {
     for (let workerGroup of this._workers.values()) {
       if (workerGroup.has(workerId)) {
         worker = workerGroup.get(workerId);
-        debug("Worker with %s id found, %o", workerId, worker);
+        debug('Worker with %s id found, %o', workerId, worker);
         break;
       }
     }
@@ -182,7 +210,7 @@ class Thekdar extends EventEmitter {
       });
       this._workers.get(worker.getType()).delete(workerId);
       this._workerTaskLookup.delete(workerId);
-      debug("Worker with id %s has been deleted", worker.getId());
+      debug('Worker with id %s has been deleted', worker.getId());
       return worker.kill();
     } catch (e) {
       debug(e);
@@ -196,6 +224,14 @@ class Thekdar extends EventEmitter {
 
   getTasks() {
     return this._tasks;
+  }
+
+  setMaxWorker(maxWorkers) {
+    this._maxWorkers = maxWorkers;
+  }
+
+  setMaxTaskPerWorker(maxTaskPerWorker) {
+    this._maxTaskPerWorker = maxTaskPerWorker;
   }
 }
 Thekdar.MAX_TASK_PER_WORKER = 10;

--- a/core/Worker.js
+++ b/core/Worker.js
@@ -1,8 +1,8 @@
-const Task = require("./Task");
-const path = require("path");
-const { fork } = require("child_process");
-const debug = require("debug")("Thekdar:worker");
-const events = require("./events");
+const Task = require('./Task');
+const path = require('path');
+const { fork } = require('child_process');
+const debug = require('debug')('Thekdar:worker');
+const events = require('./events');
 
 class Worker {
   constructor(type, id) {
@@ -13,10 +13,10 @@ class Worker {
   }
 
   on(handler) {
-    this._worker.on("message", data => {
+    this._worker.on('message', data => {
       handler({
         workerId: this.getId(),
-        ...data
+        ...data,
       });
     });
   }
@@ -37,7 +37,7 @@ class Worker {
   }
 
   addTask(task) {
-    debug("New task added to worker %s", this._id);
+    debug('New task added to worker %s', this._id);
     this.send(events.TASK_ADD, task);
     this._tasks.set(task.getId(), task);
   }
@@ -46,7 +46,7 @@ class Worker {
     const payload = {
       type,
       workerId: this.getId(),
-      task: data
+      task: data,
     };
     if (this._worker) {
       this._worker.send(payload);

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,0 +1,12 @@
+const Thekdar = require('../index');
+
+const Task = Thekdar.Task;
+const thekdar = new Thekdar();
+thekdar.addWorkerAddress('./examples/types/fork.js', Task.TYPE_FORK);
+thekdar.deployWorkers();
+const task = new Task();
+task.setData({
+  message: 'hello world',
+});
+task.setType(Task.TYPE_FORK);
+thekdar.addTask(task);

--- a/examples/index.js
+++ b/examples/index.js
@@ -4,9 +4,19 @@ const Task = Thekdar.Task;
 const thekdar = new Thekdar();
 thekdar.addWorkerAddress('./examples/types/fork.js', Task.TYPE_FORK);
 thekdar.deployWorkers();
-const task = new Task();
-task.setData({
-  message: 'hello world',
-});
-task.setType(Task.TYPE_FORK);
-thekdar.addTask(task);
+
+setInterval(() => {
+  const task = new Task();
+  task.setData({
+    message: 'hello world',
+  });
+  task.setType(Task.TYPE_FORK);
+  thekdar.addTask(task);
+  thekdar.setMaxTaskPerWorker(10);
+  for (let [workerId, works] of thekdar._workerTaskLookup) {
+    console.log(workerId, works.length);
+  }
+  console.log(
+    '================================================================'
+  );
+}, 500);

--- a/examples/types/fork.js
+++ b/examples/types/fork.js
@@ -1,1 +1,12 @@
-process.on('message', console.log);
+process.on('message', data => {
+  // console.log(data);
+
+  setTimeout(() => {
+    process.send({
+      type: 'task:complete',
+      taskId: data.task.id,
+      workerId: data.workerId,
+      data: {},
+    });
+  }, Math.round(Math.random() * 5000) + 3000);
+});

--- a/examples/types/fork.js
+++ b/examples/types/fork.js
@@ -1,14 +1,1 @@
-const getPort = require("get-port");
-const http = require("http");
-
-// const server = http.createServer((req, res) => {
-process.send({
-  type: "random",
-  time: Date.now()
-});
-// res.end("hello world");
-// });
-// getPort().then(port => {
-// console.log(`Server listening on port ${port}`);
-// server.listen(port);
-// });
+process.on('message', console.log);


### PR DESCRIPTION
  Deploy all worker at once and make them ready for next task instead of creating worker just before task. work division will be some kind of round robin
since we can't determine brust time which will make us unable to decide time quantum.

Task division will be done looking workload of worker like if worker 1 is doing 1 task but can do 9 more task and Worker 2 is idle then the task will be provided to Worker 2.
